### PR TITLE
Fix list of management commands to run.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ django_enabled: yes                           # The role is enabled
 django_manage_list:                           # List of commands which will be executed
   - collectstatic
   - syncdb
-  - manage
+  - migrate
 django_app_path: "{{wsgi_app_dir}}"           # Path to django application
 django_settings_imports:
   - from .{{deploy_environment}} import *


### PR DESCRIPTION
This lists a "manage" management command for some reason, I believe this is a typo. Should probably be "migrate"?
